### PR TITLE
Erebor Madness Hero Fixes

### DIFF
--- a/scenario-dsl/src/main/kotlin/bfme/domain/Army.kt
+++ b/scenario-dsl/src/main/kotlin/bfme/domain/Army.kt
@@ -148,6 +148,16 @@ enum class Army(
         "Isengard_EliteArmy",
         "Wild_EliteArmy",
         "Angmar_EliteArmy"
+    ),
+    RING_ARMY(
+        "RingHeroArmy",
+        "GaladrielArmy",
+        "GaladrielArmy",
+        "GaladrielArmy",
+        "SauronArmy",
+        "SauronArmy",
+        "SauronArmy",
+        "SauronArmy"
     );
 
     /**

--- a/scenario-dsl/src/main/kotlin/bfme/scenarios/Scenario105.kt
+++ b/scenario-dsl/src/main/kotlin/bfme/scenarios/Scenario105.kt
@@ -105,6 +105,7 @@ fun ereborMadness(): String = livingWorldCampaign {
 
             spawnArmies {
                 army(EXTRA_HERO_ONE_ARMY)
+                army(HERO_ARMY_5)
                 army(FORTRESS_ATTACK_ARMY)
                 army(FORTRESS_DEFENSE_ARMY)
                 region = DOL_GULDUR
@@ -130,6 +131,7 @@ fun ereborMadness(): String = livingWorldCampaign {
 
             spawnArmies {
                 army(EXTRA_HERO_ONE_ARMY)
+                army(HERO_ARMY_5)
                 army(FORTRESS_ATTACK_ARMY)
                 army(FORTRESS_DEFENSE_ARMY)
                 region = EREBOR
@@ -302,15 +304,14 @@ fun ereborMadness(): String = livingWorldCampaign {
         "Eight" to listOf(FORTRESS_ATTACK_ARMY, FORTRESS_ATTACK_ARMY, FORTRESS_ATTACK_ARMY, ELITE_ARMY),
         "Nine" to listOf(
             FORTRESS_ATTACK_ARMY, FORTRESS_ATTACK_ARMY, FORTRESS_ATTACK_ARMY, ELITE_ARMY,
-            SPECIALTY_THREE_ARMY, SPECIALTY_THREE_ARMY, SPECIALTY_THREE_ARMY,
-            HERO_ARMY_1, HERO_ARMY_2, HERO_ARMY_3, HERO_ARMY_4, HERO_ARMY_5
+            SPECIALTY_THREE_ARMY, SPECIALTY_THREE_ARMY, SPECIALTY_THREE_ARMY
         ),
         "Ten" to listOf(
             FORTRESS_ATTACK_ARMY, FORTRESS_ATTACK_ARMY, FORTRESS_ATTACK_ARMY, ELITE_ARMY,
             SPECIALTY_THREE_ARMY, SPECIALTY_THREE_ARMY, SPECIALTY_THREE_ARMY,
             SPECIALTY_ONE_ARMY, SPECIALTY_ONE_ARMY, SPECIALTY_ONE_ARMY,
             SPECIALTY_TWO_ARMY, SPECIALTY_TWO_ARMY, SPECIALTY_TWO_ARMY,
-            HERO_ARMY_1, HERO_ARMY_2, HERO_ARMY_3, HERO_ARMY_4, HERO_ARMY_5
+            RING_ARMY
         ),
     )
 

--- a/scenario-dsl/src/main/resources/data/ini/campaigns/common/livingworlddefaultarmies.inc
+++ b/scenario-dsl/src/main/resources/data/ini/campaigns/common/livingworlddefaultarmies.inc
@@ -130,6 +130,14 @@ SpawnArmy
     Icon = MoWArmyIcon
 End
 
+SpawnArmy
+    ScriptingName = RingHeroArmy
+    SpawnAtActStart = No
+    SpawnForTemplates = PlayerMen
+    PlayerArmy = GaladrielArmy
+    Icon = MoWArmyIcon
+End
+
 //-------------------------------------------------------------------------------------------------
 // Elves
 //-------------------------------------------------------------------------------------------------
@@ -256,6 +264,13 @@ SpawnArmy
     Icon = ElfArmyIcon
 End
 
+SpawnArmy
+    ScriptingName = RingHeroArmy
+    SpawnAtActStart = No
+    SpawnForTemplates = PlayerElves
+    PlayerArmy = GaladrielArmy
+    Icon = ElfArmyIcon
+End
 
 //-------------------------------------------------------------------------------------------------
 // Dwarves
@@ -367,6 +382,13 @@ SpawnArmy
     Icon = DwarfArmyIcon
 End
 
+SpawnArmy
+    ScriptingName = RingHeroArmy
+    SpawnAtActStart = No
+    SpawnForTemplates = PlayerDwarves
+    PlayerArmy = GaladrielArmy
+    Icon = DwarfArmyIcon
+End
 
 //-------------------------------------------------------------------------------------------------
 // Mordor
@@ -478,6 +500,13 @@ SpawnArmy
     Icon = MordorArmyIcon
 End
 
+SpawnArmy
+    ScriptingName = RingHeroArmy
+    SpawnAtActStart = No
+    SpawnForTemplates = PlayerMordor
+    PlayerArmy = SauronArmy
+    Icon = MordorArmyIcon
+End
 
 //-------------------------------------------------------------------------------------------------
 // Isengard
@@ -589,6 +618,13 @@ SpawnArmy
     Icon = IsengardArmyIcon
 End
 
+SpawnArmy
+    ScriptingName = RingHeroArmy
+    SpawnAtActStart = No
+    SpawnForTemplates = PlayerIsengard
+    PlayerArmy = SauronArmy
+    Icon = IsengardArmyIcon
+End
 
 //-------------------------------------------------------------------------------------------------
 // Wild
@@ -697,6 +733,14 @@ SpawnArmy
     SpawnAtActStart = No
     SpawnForTemplates = PlayerWild
     PlayerArmy = Wild_EliteArmy
+    Icon = WildArmyIcon
+End
+
+SpawnArmy
+    ScriptingName = RingHeroArmy
+    SpawnAtActStart = No
+    SpawnForTemplates = PlayerWild
+    PlayerArmy = SauronArmy
     Icon = WildArmyIcon
 End
 
@@ -810,3 +854,10 @@ SpawnArmy
     Icon = AngmarArmyIcon
 End
 
+SpawnArmy
+    ScriptingName = RingHeroArmy
+    SpawnAtActStart = No
+    SpawnForTemplates = PlayerAngmar
+    PlayerArmy = SauronArmy
+    Icon = AngmarArmyIcon
+End

--- a/scenario-dsl/src/main/resources/data/ini/campaigns/common/livingworldstartingunits.inc
+++ b/scenario-dsl/src/main/resources/data/ini/campaigns/common/livingworldstartingunits.inc
@@ -2063,3 +2063,22 @@ LivingWorldPlayerArmy
         Quantity = 1
     End
 End
+
+// Ring Heros
+LivingWorldPlayerArmy
+    Name = SauronArmy
+    DisplayNameTag = LWA:Garrison
+    ArmyEntry
+        ThingTemplate = MordorSauron_RingHero
+        Quantity = 1
+    End
+End
+
+LivingWorldPlayerArmy
+    Name = GaladrielArmy
+    DisplayNameTag = LWA:Garrison
+    ArmyEntry
+        ThingTemplate = ElvenGaladriel_RingHero
+        Quantity = 1
+    End
+End

--- a/scenario-dsl/src/main/resources/data/ini/campaigns/scenarios/wotrscenario105.inc
+++ b/scenario-dsl/src/main/resources/data/ini/campaigns/scenarios/wotrscenario105.inc
@@ -95,7 +95,7 @@ LivingWorldCampaign WOTRScenario105
             StartRegion = Dol_Guldur
 
             SpawnArmies
-                Armies = ExtraHeroOneArmy FortressAttackArmy FortressDefenseArmy
+                Armies = ExtraHeroOneArmy HeroArmy5 FortressAttackArmy FortressDefenseArmy
                 Region = Dol_Guldur
             End
 
@@ -116,7 +116,7 @@ LivingWorldCampaign WOTRScenario105
             StartRegion = Erebor
 
             SpawnArmies
-                Armies = ExtraHeroOneArmy FortressAttackArmy FortressDefenseArmy
+                Armies = ExtraHeroOneArmy HeroArmy5 FortressAttackArmy FortressDefenseArmy
                 Region = Erebor
             End
 
@@ -1152,46 +1152,6 @@ LivingWorldCampaign WOTRScenario105
 
         SpawnArmy
             ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerMordor
-            PlayerArmy = WitchKingPlayerArmy
-            Icon = MordorArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerMordor
-            PlayerArmy = FellBeast1PlayerArmy
-            Icon = MordorArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerMordor
-            PlayerArmy = MouthOfSauronArmy
-            Icon = MordorArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerMordor
-            PlayerArmy = GothmogPlayerArmy
-            Icon = MordorArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerMordor
-            PlayerArmy = Mordor_CreateAHeroArmy
-            Icon = MordorArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
             SpawnForTemplates = PlayerDwarves
             PlayerArmy = Dwarven_FortressAttackArmy
             Icon = DwarfArmyIcon
@@ -1242,46 +1202,6 @@ LivingWorldCampaign WOTRScenario105
             ScriptingName = ExtraArmy
             SpawnForTemplates = PlayerDwarves
             PlayerArmy = Dwarven_SpecialtyThreeArmy
-            Icon = DwarfArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerDwarves
-            PlayerArmy = GimliPlayerArmy
-            Icon = DwarfArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerDwarves
-            PlayerArmy = DainPlayerArmy
-            Icon = DwarfArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerDwarves
-            PlayerArmy = GloinPlayerArmy
-            Icon = DwarfArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerDwarves
-            PlayerArmy = CaptainofDalePlayerArmy
-            Icon = DwarfArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerDwarves
-            PlayerArmy = Dwarven_CreateAHeroArmy
             Icon = DwarfArmyIcon
             SpawnAtActStart = Yes
         End
@@ -1344,46 +1264,6 @@ LivingWorldCampaign WOTRScenario105
 
         SpawnArmy
             ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerIsengard
-            PlayerArmy = SarumanPlayerArmy
-            Icon = IsengardArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerIsengard
-            PlayerArmy = LurtzPlayerArmy
-            Icon = IsengardArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerIsengard
-            PlayerArmy = SharkuPlayerArmy
-            Icon = IsengardArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerIsengard
-            PlayerArmy = WormTongueArmy
-            Icon = IsengardArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerIsengard
-            PlayerArmy = Isengard_CreateAHeroArmy
-            Icon = IsengardArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
             SpawnForTemplates = PlayerAngmar
             PlayerArmy = Angmar_FortressAttackArmy
             Icon = AngmarArmyIcon
@@ -1434,46 +1314,6 @@ LivingWorldCampaign WOTRScenario105
             ScriptingName = ExtraArmy
             SpawnForTemplates = PlayerAngmar
             PlayerArmy = Angmar_SpecialtyThreeArmy
-            Icon = AngmarArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerAngmar
-            PlayerArmy = RogashPlayerArmy
-            Icon = AngmarArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerAngmar
-            PlayerArmy = MorgramirPlayerArmy
-            Icon = AngmarArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerAngmar
-            PlayerArmy = WitchKingArmy
-            Icon = AngmarArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerAngmar
-            PlayerArmy = HwaldarPlayerArmy
-            Icon = AngmarArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerAngmar
-            PlayerArmy = Angmar_CreateAHeroArmy
             Icon = AngmarArmyIcon
             SpawnAtActStart = Yes
         End
@@ -1587,39 +1427,7 @@ LivingWorldCampaign WOTRScenario105
         SpawnArmy
             ScriptingName = ExtraArmy
             SpawnForTemplates = PlayerMordor
-            PlayerArmy = WitchKingPlayerArmy
-            Icon = MordorArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerMordor
-            PlayerArmy = FellBeast1PlayerArmy
-            Icon = MordorArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerMordor
-            PlayerArmy = MouthOfSauronArmy
-            Icon = MordorArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerMordor
-            PlayerArmy = GothmogPlayerArmy
-            Icon = MordorArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerMordor
-            PlayerArmy = Mordor_CreateAHeroArmy
+            PlayerArmy = SauronArmy
             Icon = MordorArmyIcon
             SpawnAtActStart = Yes
         End
@@ -1731,39 +1539,7 @@ LivingWorldCampaign WOTRScenario105
         SpawnArmy
             ScriptingName = ExtraArmy
             SpawnForTemplates = PlayerDwarves
-            PlayerArmy = GimliPlayerArmy
-            Icon = DwarfArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerDwarves
-            PlayerArmy = DainPlayerArmy
-            Icon = DwarfArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerDwarves
-            PlayerArmy = GloinPlayerArmy
-            Icon = DwarfArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerDwarves
-            PlayerArmy = CaptainofDalePlayerArmy
-            Icon = DwarfArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerDwarves
-            PlayerArmy = Dwarven_CreateAHeroArmy
+            PlayerArmy = GaladrielArmy
             Icon = DwarfArmyIcon
             SpawnAtActStart = Yes
         End
@@ -1875,39 +1651,7 @@ LivingWorldCampaign WOTRScenario105
         SpawnArmy
             ScriptingName = ExtraArmy
             SpawnForTemplates = PlayerIsengard
-            PlayerArmy = SarumanPlayerArmy
-            Icon = IsengardArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerIsengard
-            PlayerArmy = LurtzPlayerArmy
-            Icon = IsengardArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerIsengard
-            PlayerArmy = SharkuPlayerArmy
-            Icon = IsengardArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerIsengard
-            PlayerArmy = WormTongueArmy
-            Icon = IsengardArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerIsengard
-            PlayerArmy = Isengard_CreateAHeroArmy
+            PlayerArmy = SauronArmy
             Icon = IsengardArmyIcon
             SpawnAtActStart = Yes
         End
@@ -2019,39 +1763,7 @@ LivingWorldCampaign WOTRScenario105
         SpawnArmy
             ScriptingName = ExtraArmy
             SpawnForTemplates = PlayerAngmar
-            PlayerArmy = RogashPlayerArmy
-            Icon = AngmarArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerAngmar
-            PlayerArmy = MorgramirPlayerArmy
-            Icon = AngmarArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerAngmar
-            PlayerArmy = WitchKingArmy
-            Icon = AngmarArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerAngmar
-            PlayerArmy = HwaldarPlayerArmy
-            Icon = AngmarArmyIcon
-            SpawnAtActStart = Yes
-        End
-
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerAngmar
-            PlayerArmy = Angmar_CreateAHeroArmy
+            PlayerArmy = SauronArmy
             Icon = AngmarArmyIcon
             SpawnAtActStart = Yes
         End

--- a/scenario-dsl/src/main/resources/data/ini/campaigns/scenarios/wotrscenario200.inc
+++ b/scenario-dsl/src/main/resources/data/ini/campaigns/scenarios/wotrscenario200.inc
@@ -19,14 +19,14 @@ LivingWorldCampaign WOTRScenario200
         DisplayVictoriousText = LWScenario:WOTRScenarioWin101
         DisplayDefeatedText = LWScenario:WOTRScenarioLose101
 
-        RegionCampaign = TestingRegion
+        RegionCampaign = DefaultCampaign
 
         UseMpRulesVictoryCondition = No
         MinPlayers = 6
         MaxPlayers = 6
 
-        DisallowStartInRegions = Amon_Sul Anfalas Angmar Arnor Barrow_Downs Buckland Cair_Andros Cardolan CarnDum Carrock Celduin Dagorlad Dol_Guldur Enedwaith Erebor Ettenmoors Forlindon Fornost Forodwaith Grey_Havens Harad Harlindon Helms_Deep Isengard Ithilien Lostriand Lothlorien Minas_Morgul Minas_Tirith Minhiriath Mirkwood Mordor MountGundabad Mount_Doom Osgiliath Redhorn_Pass Rhudaur Rhun Rivendell Rohan The_Black_Gate The_Brown_Lands The_Dead_Marshes The_Shire Tower_Hills Umbar
-        DefaultStartSpots = Iron_Hills Belfalas Fangorn Gap_Of_Rohan High_Pass Dunland
+        DisableRegions = Amon_Sul Anfalas Angmar Arnor Barrow_Downs Belfalas Buckland Cair_Andros Cardolan CarnDum Carrock Dunland Enedwaith Ettenmoors Fangorn Forlindon Fornost Forodwaith Gap_Of_Rohan Grey_Havens Harad Harlindon Helms_Deep High_Pass Isengard Ithilien Lostriand Lothlorien Minas_Morgul Minas_Tirith Minhiriath Mordor MountGundabad Mount_Doom Osgiliath Redhorn_Pass Rhudaur Rhun Rivendell Rohan The_Black_Gate The_Brown_Lands The_Dead_Marshes The_Shire Tower_Hills Umbar
+        DefaultStartSpots = Dol_Guldur Erebor Celduin Mirkwood Iron_Hills Dagorlad
 
         PlayerDefeatCondition
             Teams = 1 2
@@ -40,254 +40,216 @@ LivingWorldCampaign WOTRScenario200
         End
 
         TeamVictoryCondition
-            Teams = 1 2
-            ControlledRegions = Erebor
-            ControlledRegionsHeldForTurns = 3
+            Teams = 1
+            ControlledRegions = Dol_Guldur Erebor
+            ControlledRegionsHeldForTurns = 10
+        End
+
+        TeamVictoryCondition
+            Teams = 2
+            ControlledRegions = Dol_Guldur Erebor
+            ControlledRegionsHeldForTurns = 1
         End
 
         StartingRestriction
+            Factions = FactionElves
+            Regions = Dol_Guldur
+            Teams = 1
+        End
+
+        StartingRestriction
+            Factions = FactionMen
+            Regions = Erebor
+            Teams = 1
+        End
+
+        StartingRestriction
+            Factions = FactionMordor
+            Regions = Celduin
+            Teams = 2
+        End
+
+        StartingRestriction
+            Factions = FactionDwarves
+            Regions = Mirkwood
+            Teams = 2
+        End
+
+        StartingRestriction
+            Factions = FactionIsengard
             Regions = Iron_Hills
-            Teams = 1
-        End
-
-        StartingRestriction
-            Regions = Belfalas
-            Teams = 1
-        End
-
-        StartingRestriction
-            Regions = Fangorn
             Teams = 2
         End
 
         StartingRestriction
-            Regions = Gap_Of_Rohan
-            Teams = 2
-        End
-
-        StartingRestriction
-            Regions = High_Pass
-            Teams = 2
-        End
-
-        StartingRestriction
-            Regions = Dunland
+            Factions = FactionAngmar
+            Regions = Dagorlad
             Teams = 2
         End
 
         ; Player One
         OwnershipSet
-            Regions = Iron_Hills Anfalas
-            StartRegion = Iron_Hills
+            Regions = Dol_Guldur
+            StartRegion = Dol_Guldur
 
             SpawnArmies
-                Armies = HeroArmy1 GarrisonArmy1
-                Region = Iron_Hills
+                Armies = ExtraHeroOneArmy HeroArmy5 FortressAttackArmy FortressDefenseArmy FortressAttackArmy
+                Region = Dol_Guldur
             End
 
             SpawnArmies
-                Armies = HeroArmy2
-                Region = Iron_Hills
-            End
-
-            SpawnArmies
-                Armies = HeroArmy3 GarrisonArmy1
-                Region = Belfalas
-            End
-
-            SpawnArmies
-                Armies = HeroArmy5
-                Region = Belfalas
+                Armies = ExtraHeroTwoArmy FortressAttackArmy FortressDefenseArmy FortressAttackArmy
+                Region = Erebor
             End
 
             SpawnBuildings
-                Buildings = LW_BARRACKS LW_SUPER_FARM
-                Region = Iron_Hills
-            End
-
-            SpawnBuildings
-                Buildings = LW_FORT LW_SUPER_FARM
-                Region = Anfalas
+                Buildings = LW_ARMORY
+                Region = Dol_Guldur
             End
         End
 
         ; Player Two
         OwnershipSet
-            Regions = Belfalas Rhun
-            StartRegion = Belfalas
+            Regions = Erebor
+            StartRegion = Erebor
 
             SpawnArmies
-                Armies = HeroArmy1 GarrisonArmy1
-                Region = Belfalas
+                Armies = ExtraHeroOneArmy HeroArmy5 FortressAttackArmy FortressDefenseArmy FortressAttackArmy
+                Region = Erebor
             End
 
             SpawnArmies
-                Armies = HeroArmy2
-                Region = Belfalas
-            End
-
-            SpawnArmies
-                Armies = HeroArmy3 GarrisonArmy1
-                Region = Iron_Hills
-            End
-
-            SpawnArmies
-                Armies = HeroArmy5
-                Region = Iron_Hills
+                Armies = ExtraHeroTwoArmy FortressAttackArmy FortressDefenseArmy FortressAttackArmy
+                Region = Dol_Guldur
             End
 
             SpawnBuildings
-                Buildings = LW_BARRACKS LW_SUPER_FARM
-                Region = Belfalas
-            End
-
-            SpawnBuildings
-                Buildings = LW_BARRACKS LW_SUPER_FARM
-                Region = Rhun
+                Buildings = LW_ARMORY
+                Region = Erebor
             End
         End
 
         ; Computer 1
         OwnershipSet
-            Regions = Fangorn Forlindon
-            StartRegion = Fangorn
+            Regions = Celduin
+            StartRegion = Celduin
 
             SpawnArmies
-                Armies = HeroArmy1 GarrisonArmy1
-                Region = Fangorn
+                Armies = HeroArmy1
+                Region = Celduin
             End
 
             SpawnArmies
                 Armies = HeroArmy2
-                Region = Forlindon
+                Region = Mirkwood
             End
 
             SpawnArmies
                 Armies = HeroArmy3
-                Region = High_Pass
+                Region = Iron_Hills
             End
 
             SpawnArmies
-                Armies = HeroArmy5
-                Region = Dunland
+                Armies = HeroArmy4
+                Region = Dagorlad
             End
 
             SpawnBuildings
-                Buildings = LW_FARM LW_SUPER_FARM
-                Region = Fangorn
-            End
-
-            SpawnBuildings
-                Buildings = LW_FORT LW_BARRACKS
-                Region = Forlindon
+                Buildings = LW_FORT LW_FARM
+                Region = Celduin
             End
         End
 
         ; Computer 2
         OwnershipSet
-            Regions = Gap_Of_Rohan Harlindon
-            StartRegion = Gap_Of_Rohan
+            Regions = Mirkwood
+            StartRegion = Mirkwood
 
             SpawnArmies
                 Armies = HeroArmy1
-                Region = Harlindon
+                Region = Mirkwood
             End
 
             SpawnArmies
-                Armies = HeroArmy2 GarrisonArmy1
-                Region = Gap_Of_Rohan
+                Armies = HeroArmy2
+                Region = Iron_Hills
             End
 
             SpawnArmies
                 Armies = HeroArmy3
-                Region = High_Pass
+                Region = Dagorlad
             End
 
             SpawnArmies
-                Armies = HeroArmy5
-                Region = Dunland
+                Armies = HeroArmy4
+                Region = Celduin
             End
 
             SpawnBuildings
-                Buildings = LW_FARM LW_SUPER_FARM
-                Region = Gap_Of_Rohan
-            End
-
-            SpawnBuildings
-                Buildings = LW_FORT LW_BARRACKS
-                Region = Harlindon
+                Buildings = LW_FORT LW_FARM LW_BARRACKS
+                Region = Mirkwood
             End
         End
 
         ; Computer 3
         OwnershipSet
-            Regions = High_Pass Forodwaith
-            StartRegion = High_Pass
+            Regions = Iron_Hills
+            StartRegion = Iron_Hills
 
             SpawnArmies
                 Armies = HeroArmy1
-                Region = Fangorn
+                Region = Iron_Hills
             End
 
             SpawnArmies
                 Armies = HeroArmy2
-                Region = Gap_Of_Rohan
+                Region = Dagorlad
             End
 
             SpawnArmies
-                Armies = HeroArmy3 GarrisonArmy1
-                Region = High_Pass
+                Armies = HeroArmy3
+                Region = Celduin
             End
 
             SpawnArmies
-                Armies = HeroArmy5
-                Region = Forodwaith
+                Armies = HeroArmy4
+                Region = Mirkwood
             End
 
             SpawnBuildings
-                Buildings = LW_FARM LW_SUPER_FARM
-                Region = High_Pass
-            End
-
-            SpawnBuildings
-                Buildings = LW_FORT LW_BARRACKS
-                Region = Forodwaith
+                Buildings = LW_FORT LW_FARM LW_BARRACKS
+                Region = Iron_Hills
             End
         End
 
         ; Computer 4
         OwnershipSet
-            Regions = Dunland Arnor
-            StartRegion = Dunland
+            Regions = Dagorlad
+            StartRegion = Dagorlad
 
             SpawnArmies
                 Armies = HeroArmy1
-                Region = Fangorn
+                Region = Dagorlad
             End
 
             SpawnArmies
                 Armies = HeroArmy2
-                Region = Gap_Of_Rohan
+                Region = Celduin
             End
 
             SpawnArmies
                 Armies = HeroArmy3
-                Region = Arnor
+                Region = Mirkwood
             End
 
             SpawnArmies
-                Armies = HeroArmy5 GarrisonArmy1
-                Region = Dunland
+                Armies = HeroArmy4
+                Region = Iron_Hills
             End
 
             SpawnBuildings
-                Buildings = LW_FARM LW_SUPER_FARM
-                Region = Dunland
-            End
-
-            SpawnBuildings
-                Buildings = LW_FORT LW_BARRACKS
-                Region = Arnor
+                Buildings = LW_FORT LW_FARM
+                Region = Dagorlad
             End
         End
     End
@@ -319,93 +281,27 @@ LivingWorldCampaign WOTRScenario200
         SpawnArmy
             ScriptingName = ExtraArmy
             SpawnForTemplates = PlayerMen
-            PlayerArmy = MenOfTheWest_FortressAttackArmy
+            PlayerArmy = GaladrielArmy
             Icon = MoWArmyIcon
             SpawnAtActStart = Yes
         End
         SpawnArmy
             ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerElves
-            PlayerArmy = Elven_FortressAttackArmy
-            Icon = ElfArmyIcon
-            SpawnAtActStart = Yes
-        End
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerElves
-            PlayerArmy = LegolasArmy
-            Icon = ElfArmyIcon
-            SpawnAtActStart = Yes
-        End
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerElves
-            PlayerArmy = ElrondArmy
-            Icon = ElfArmyIcon
-            SpawnAtActStart = Yes
-        End
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerDwarves
-            PlayerArmy = Dwarven_FortressAttackArmy
-            Icon = DwarfArmyIcon
-            SpawnAtActStart = Yes
-        End
-        SpawnArmy
-            ScriptingName = MineArmy
             SpawnForTemplates = PlayerIsengard
-            PlayerArmy = Isengard_MineArmy
-            Icon = IsengardArmyIcon
+            PlayerArmy = SauronArmy
+            Icon = IsengardIcon
             SpawnAtActStart = Yes
         End
     End
+
     Act Three
         SpawnArmy
             ScriptingName = ExtraArmy
             SpawnForTemplates = PlayerElves
-            PlayerArmy = Elven_FortressAttackArmy
+            PlayerArmy = ThranduilPlayerArmy
             Icon = ElfArmyIcon
             SpawnAtActStart = Yes
+            Banner = BannerElves
         End
-        SpawnArmy
-            ScriptingName = ExtraArmy
-            SpawnForTemplates = PlayerElves
-            PlayerArmy = LegolasArmy
-            Icon = ElfArmyIcon
-            SpawnAtActStart = Yes
-        End
-    End
-End
-
-LivingWorldRegionCampaign TestingRegion
-    RegionConqueredSound = Gui_RegionConquered
-    RegionEffectsManagerName = WotRRegionEffects
-    RegionBonusArmy = LW:RegionBonusArmy_Good
-    RegionBonusResource = LW:RegionBonusResource
-    RegionBonusLegendary = LW:RegionLegendaryBonus
-    HeroOnlyArmyCommandPoints = 0
-    SmallArmyCommandPoints = 120
-    MediumArmyCommandPoints = 240
-
-    // Regions
-    #include "..\common\livingworldregionswithoutbonus.inc"
-
-    ConcurrentRegionBonus
-        Territory = LW:TerritoryCustom
-        EffectName = CustomEffect
-        Regions = Iron_Hills
-        ArmyBonus = 0
-        ResourceBonus = 1
-        LegendaryBonus = 5
-        AttackBonus = 1
-        DefenseBonus = 5
-        ExperienceBonus = 4
-        FreeInnUnitsBonus = 2
-        FreeBuilderBonus = 3
-        UnifiedEvaEvent = WorldUnifyNorthernWastes
-        LostEvaEvent = WorldLostNorthernWastes
-        LookAtCenter = X:-65 Y:2085
-        LookAtHeading = 0
-        LookAtZoom = 0.71
     End
 End


### PR DESCRIPTION
- Spawn create a heros on turn 1
- Do not spawn duplicate heros to avoid crashes
- Give computers ring heros on turn 10